### PR TITLE
vim: add splitjoin, add to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ I keep forgetting how I set up clean machines, IDEs, editors and tools. Here's t
 
 - `[<Space>` - blank line above
 - `]<Space>` - blank line below
+- `sj` - Splitjoin down (i.e. split a line downwards).
+- `sk` - Splitjoin up (i.e. join a line upwards).
 - `<leader>r` - Open current file in NERDTree.
 - `<leader>w` - Write buffer.
 - `<leader>\` - Open buffer in new tab.
-- `<leader>d` - Open word under cursor in Dash
+- `<leader>d` - Open word under cursor in Dash.
 - `<leader>t` - Show current buffer in NERDTree.
 
 

--- a/vimrc
+++ b/vimrc
@@ -42,6 +42,9 @@ Plugin 'tmux-plugins/vim-tmux-focus-events'
 " Lots of mappings such as [<Space> ]<Space>.
 Plugin 'tpope/vim-unimpaired'
 
+" Nice splitting / joining.
+Plugin 'AndrewRadev/splitjoin.vim'
+
 " all of your Plugins must be added before the following line
 call vundle#end()            " required
 filetype plugin indent on    " required
@@ -209,6 +212,11 @@ inoremap <leader>s <C-c>:w<cr>
 
 " NERD Commenter plugin.
 Plugin 'scrooloose/nerdcommenter'
+
+" Splitjoin Plugin
+" Remember it like this: 's' for 'split', j splits down, k up.
+nmap sj :SplitjoinSplit<cr>
+nmap sk :SplitjoinJoin<cr>
 
 " Add a space after each comment delimiter.
 let g:NERDSpaceDelims = 1


### PR DESCRIPTION
Adds the splitjoin plugin. `sj` to split down (i.e. split) and
`sk` to split up (i.e. join).