### PR TITLE
feat: support docker auto-completions

### DIFF
--- a/profile.sh
+++ b/profile.sh
@@ -1,3 +1,14 @@
+# IMPORTANT:
+#
+# There is no shebang in this script. This will be sourced from the user's
+# current shell. So we might be using bash, zsh, etc. If we use an explicit
+# shebang, we can guarantee the shell which will interpret the script, but
+# cannot conditionally set up the user's _current_ shell.
+#
+# See the section near the end where we are sourcing auto-complete settings for
+# an example of why this matters. If we use a shebang in this script, we'll only
+# ever source auto-completions for the shell in the shebang.
+
 #!/usr/bin/env bash
 
 # Import everything from the .profile folder.
@@ -43,8 +54,19 @@ export PS1="\[\033[38;5;10m\]\h\[$(tput sgr0)\]\[\033[38;5;15m\] \[$(tput sgr0)\
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 
-# Whether we're in iTerm, Terminal or whatever, we're using tmux.
 # If we are not running in interactive mode, we're done.
-# Otherwise, unless we are *already* in a tmux session, start tmux.
 [[ $- != *i* ]] && return
+
+# We *are* interactive, so if we are not already in tmux, start it.
 [[ -z "$TMUX" ]] && exec tmux
+
+# Load auto-completions depending on our shell.
+if [ -n "$BASH_VERSION" ]; then
+    # Source auto-completions from the Mac and Linux locations.
+    if [ -f /usr/local/etc/bash_completion ]; then . /usr/local/etc/bash_completion; fi
+    if [ -f /etc/bash_completion ]; then . /etc/bash_completion; fi
+elif [ -n "$ZSH_VERSION" ]; then
+    # Source zsh auto-completions.
+    fpath=(~/.zsh/completion $fpath)
+    autoload -Uz compinit && compinit -i
+fi

--- a/setup.d/docker-autocompletion.sh
+++ b/setup.d/docker-autocompletion.sh
@@ -1,0 +1,37 @@
+# Check if the user wants the feature, bail if not.
+if ! ask "$os: setup docker autocompletion?" Y; then
+    return 0
+fi
+
+# Note the standard bash and zsh autocompletion paths.
+bash_autocomplete_dir="/etc/bash_completion.d"
+zsh_autocomplete_dir="${HOME}/.zsh/completion"
+
+# If we are on a Mac, we might not have auto-completion installed (for Linux, it
+# should already be good to go).
+if [[ "$os" == "osx" ]]; then
+    echo "$os: installing bash-completion..."
+    brew install bash-completion
+    bash_autocomplete_dir="$(brew --prefix)${bash_autocomplete_dir}"
+fi
+
+# Ensure the completion paths exist.
+sudo mkdir -p "${bash_autocomplete_dir}"
+mkdir -p "${zsh_autocomplete_dir}"
+
+# Download the bash autocompletion script scripts.
+sudo curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker -o \
+    "${bash_autocomplete_dir}/docker"
+sudo curl -L https://raw.githubusercontent.com/docker/compose/1.24.0/contrib/completion/bash/docker-compose -o \
+    "${bash_autocomplete_dir}/docker-compose"
+sudo curl -L https://raw.githubusercontent.com/docker/machine/v0.16.0/contrib/completion/bash/docker-machine.bash -o \
+    "${bash_autocomplete_dir}/docker-machine"
+
+# Download the zsh autocompletion scripts.
+curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/zsh/_docker -o \
+    "${zsh_autocomplete_dir}/_docker"
+curl -L https://raw.githubusercontent.com/docker/compose/1.24.0/contrib/completion/zsh/_docker-compose -o \
+    "${zsh_autocomplete_dir}/_docker-compose"
+curl -L https://raw.githubusercontent.com/docker/machine/v0.16.0/contrib/completion/zsh/_docker-machine -o \
+    "${zsh_autocomplete_dir}/_docker-machine"
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,8 @@
-
-source ./tools/ask.sh
-source ./tools/ensure_symlink.sh
+# Load each of the tools.
+for file in ./tools/*; do
+    [ -e "$file" ] || continue
+    source $file
+done
 
 # TODO:
 # osx - mas (mac app store CLI: brew)
@@ -9,19 +11,10 @@ source ./tools/ensure_symlink.sh
 # terminal - raise bug on broken colours
 # shell - tldr
 
-# Identify the operating system.
-un=$(uname -a)
-os="unknown"
-if [[ "$un" =~ [Dd]arwin ]]; then
-    echo "Operating System: OSX"
-    os="osx"
-elif [[ "$un" =~ [Uu]buntu ]]; then
-    echo "Operating System: Ubuntu"
-    os="ubuntu"
-else
-    echo "Operating System: Unknown"
-    exit 1
-fi
+# Get the operating system, output it. The script will terminate if the OS
+# cannot be categorically identified.
+os=$(get_os)
+echo "os identified as: $os"
 
 # Perform MacOSX Dock Configuration.
 if [[ "$os" == "osx" ]]; then
@@ -358,7 +351,11 @@ if ask "$os: Some changes may require a restart - restart now?" Y; then
     git config --global gpg.program "gpg2"
 fi
 
-
+# Run each of the setup files.
+for file in ./setup.d/*; do
+    [ -e "$file" ] || continue
+    source $file
+done
 
 exit;
 # NOTE: We need to support upgrading tmux too...
@@ -398,13 +395,6 @@ fi
 
 # Re-attach to user namespace is needed to get the system clipboard setup.
 brew install reattach-to-user-namespace
-brew install bash-completion
-
-# Not sure if we want this here, but here's some zsh completion...
-mkdir -p ~/.zsh/completion
-curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/zsh/_docker > ~/.zsh/completion/_docker
-curl -L https://raw.githubusercontent.com/docker/machine/v0.13.0/contrib/completion/zsh/_docker-machine > ~/.zsh/completion/_docker-machine
-curl -L https://raw.githubusercontent.com/docker/compose/1.17.0/contrib/completion/zsh/_docker-compose > ~/.zsh/completion/_docker-compose
 
 # Install linters and related tools. These are used by ALE in Vim.
 

--- a/tools/get_os.sh
+++ b/tools/get_os.sh
@@ -1,0 +1,17 @@
+# Echo's the operating system, simplified to:
+# - osx
+# - ubuntu
+function get_os() {
+    # Identify the operating system.
+    local un=$(uname -a)
+    os="unknown"
+    if [[ "$un" =~ [Dd]arwin ]]; then
+        echo "osx"
+    elif [[ "$un" =~ [Uu]buntu ]]; then
+        echo "Operating System: Ubuntu"
+        echo "ubuntu"
+    else
+        logger -s "Unable to idenfify operating system from uname '$un'"
+        exit 1
+    fi
+}


### PR DESCRIPTION
FYI @mindmelting.

This PR:

- Adds docker, docker machine and docker compose auto-completions
- Completely fixes the issue where the `.profile.sh` file always assumed we were in bash
- Moves one step closer to separating each setup operation into its own file