### PR TITLE
fix: posix compliant check to see if java is installed

### DIFF
--- a/profile/java.sh
+++ b/profile/java.sh
@@ -2,7 +2,13 @@
 
 # If we have Java installed, then set the JAVA_HOME directory and make sure
 # the JAVA_HOME is in the bin path.
-if [ -n `which java` ]; then
-    export JAVA_HOME=$(/usr/libexec/java_home)
-    export PATH=${JAVA_HOME}/bin:$PATH
+if [ -x "$(command -v "java")" ]; then
+    if [ -f "/usr/libexec/java_home" ]; then
+        # If we have the java_home util (i.e. on a Mac) then use it...
+        export JAVA_HOME="$(/usr/libexec/java_home)";
+        export PATH="${JAVA_HOME}/bin:$PATH";
+    elif [ -f "$(which javac)" ]; then
+        # ...otherwise try and work it out from the location of javac.
+        export JAVA_HOME=$(dirname $(dirname $(readlink -e $(which javac))));
+    fi
 fi


### PR DESCRIPTION
This updated script works on both OSX an Ubuntu, as well as bash and
zsh. It correctly checks whether there is a java executable, and sets
the JAVA_HOME appropriately.