### PR TITLE
feat(vim): better markdown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ My setup for MacOSX and Linux, with a focus on terminal, editor, shell, programm
 
 **Screenshot on MacOSX**
 
-![Screensho: MacOSX](./docs/screenshot_macosx.png)
+![Screenshot: MacOSX](./docs/screenshot_macosx.png)
 
 **Screenshot on Ubuntu**
 
@@ -140,6 +140,9 @@ The following shell commands are setup:
 | **Spelling**     |                                                |
 | `]s` and `[s`    | Next/Previous spelling error.                  |
 | `z=` and `zg`    | Check dictionary / add to dictionary.          |
+| **Markdown**     | Provided by `vim-markdown`                     |
+| `]]` and `[[`    | Next and previous headers.                     |
+| `gx`             | Open link in standard editor.                  |
 
 ### Cheat Sheet
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -33,13 +33,13 @@ Plug 'pangloss/vim-javascript'  " Better syntax and indenting for js.
 Plug 'elzr/vim-json'            " As above.
 Plug 'othree/html5.vim'         " HTML + SVG
 Plug 'hashivim/vim-terraform'   " Adds suppport for terraform files (in fact HCP etc)
-Plug 'godlygeek/tabular'        " Line up text! Needed by vim-markdown.
 Plug 'mzlogin/vim-markdown-toc' " Build a TOC for markdown.
 Plug 'leafgarland/typescript-vim' "TypeScript
 Plug 'ianks/vim-tsx'
 
-Plug 'plasticboy/vim-markdown'                    " Markdown support. Not yet sure if this is worth it. Doesn't colour headers, gets list indentation wrong.
-" Plug 'gabrielelana/vim-markdown'
+" Plugins for markdown.
+Plug 'godlygeek/tabular'        " Line up text! Needed by vim-markdown.
+Plug 'plasticboy/vim-markdown'  " Markdown support.
 
 " Support focus events, even when running in tmux.
 Plug 'tmux-plugins/vim-tmux-focus-events'

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -38,7 +38,7 @@ Plug 'mzlogin/vim-markdown-toc' " Build a TOC for markdown.
 Plug 'leafgarland/typescript-vim' "TypeScript
 Plug 'ianks/vim-tsx'
 
-" Plug 'plasticboy/vim-markdown'                    " Markdown support. Not yet sure if this is worth it. Doesn't colour headers, gets list indentation wrong.
+Plug 'plasticboy/vim-markdown'                    " Markdown support. Not yet sure if this is worth it. Doesn't colour headers, gets list indentation wrong.
 " Plug 'gabrielelana/vim-markdown'
 
 " Support focus events, even when running in tmux.


### PR DESCRIPTION
Re-enable [vim-markdown](https://github.com/plasticboy/vim-markdown) which now seems to highlight headers properly, works with code better, and has some useful features such as `[[` and `]]` to move around headers. Still lots more to explore.