### PR TITLE
feat: add Claude guidelines with comment standards and PR requirements

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+/Users/Dave_Kerr/.claude/CLAUDE.md

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,1 +1,58 @@
-/Users/Dave_Kerr/.claude/CLAUDE.md
+# CLAUDE.md
+
+# Comments Guidelines
+
+**NEVER add breadcrumb comments** that simply describe what the code does or what it was changed from. Instead, use comments to explain WHY the current approach was chosen.
+
+## Bad Comments (breadcrumbs):
+```javascript
+// Changed from Promise.all to sequential processing to avoid API rate limits
+// Loop through all users  
+// Check if user is active
+// Send notification to user
+```
+
+## Good Comments (reasoning):
+```javascript
+// Process sequentially to avoid hitting API rate limits
+users.forEach(user => {
+    if (user.active) {
+        sendNotification(user);
+    }
+});
+```
+
+Other examples of good comments:
+- `// Use mutex lock to prevent race condition on shared counter`
+- `// Exponential backoff handles temporary API unavailability` 
+- `// API doesn't validate null values, so we check here`
+
+# Commit and PR Requirements
+
+CRITICAL: All commit messages and PR titles MUST follow conventional commit format (e.g., `feat:`, `fix:`, `docs:`, `chore:`).
+
+## Pull Request Format
+
+When creating pull requests, use this simple format:
+```
+## Summary
+- Brief description of changes
+```
+
+## Supported Commit Types
+- `feat`: New features
+- `fix`: Bug fixes  
+- `docs`: Documentation changes
+- `chore`: Maintenance tasks
+- `refactor`: Code refactoring
+- `test`: Test additions or changes
+- `ci`: CI/CD changes
+- `build`: Build system changes
+- `perf`: Performance improvements
+
+# Writing Style
+
+- **be concise and direct** - Remove unnecessary adjectives and verbose descriptions
+- **Use simple language** - Avoid complex explanations when simple ones work
+- **Keep descriptions brief** - 1-2 sentences maximum for each item
+- **Use active voice** - "Creates agent" not "Agent is created"

--- a/makefile
+++ b/makefile
@@ -17,9 +17,9 @@ link: # Creates symbolic links.
 	ln -sf ${PWD}/ack/ackrc ~/.ackrc
 	ln -sf ${PWD}/zsh/zshrc ~/.zshrc
 	ln -sf ${PWD}/ag/ignore ~/.ignore
-	ln -sf ${PWD}/VSCode/settings.json  '~/Library/Application Support/Code/User/settings.json'
+	mkdir -p ~/Library/Application\ Support/Code/User/ && ln -sf ${PWD}/VSCode/settings.json  ~/Library/Application\ Support/Code/User/settings.json || echo "error: can't link VSCode settings.json"
 	mkdir -p ~/.claude
-	ln -sf ${PWD}/.claude/CLAUDE.md ~/.claude/CLAUDE.md
+	ln -sf ${PWD}/.claude/CLAUDE.md ~/.claude/CLAUDE.md || echo "error: can't link CLAUDE.md"
 
 .PHONY: private-files-backup
 private-files-backup: # Backup private config files (ssh keys etc).

--- a/makefile
+++ b/makefile
@@ -18,6 +18,8 @@ link: # Creates symbolic links.
 	ln -sf ${PWD}/zsh/zshrc ~/.zshrc
 	ln -sf ${PWD}/ag/ignore ~/.ignore
 	ln -sf ${PWD}/VSCode/settings.json  '~/Library/Application Support/Code/User/settings.json'
+	mkdir -p ~/.claude
+	ln -sf ${PWD}/.claude/CLAUDE.md ~/.claude/CLAUDE.md
 
 .PHONY: private-files-backup
 private-files-backup: # Backup private config files (ssh keys etc).


### PR DESCRIPTION
## Summary
- Add CLAUDE.md with comment guidelines to avoid breadcrumb comments
- Include conventional commit requirements for PR titles  
- Define good vs bad comment examples focusing on WHY not WHAT
- Add writing style guidelines for concise, direct communication