### PR TITLE
docs: add Claude plugins documentation and GitHub access instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,9 +241,39 @@ This also installs common CLI applications, such as `tree`, as well as GNU tools
 
 **Claude Code**
 
-Configuration for Claude Code CLI is managed via symlinks. Settings are stored in `claude/settings.json` and linked to `~/.claude/settings.json`.
+Configuration for Claude Code CLI is managed via symlinks:
+- `claude/CLAUDE.md` → `~/.claude/CLAUDE.md`
+- `claude/settings.json` → `~/.claude/settings.json`
+- `claude/statusline.sh` → `~/.claude/statusline.sh`
 
 To view or edit Claude Code settings, use the `/config` command within Claude Code.
+
+### Preferred Plugins
+
+After setup, install preferred marketplace plugins:
+
+```bash
+# Add marketplaces
+/plugin marketplace add dwmkerr/dwmkerr-plugins
+/plugin marketplace add anthropics/skills
+/plugin marketplace add context-engineering-marketplace
+/plugin marketplace add claude-toolkit
+
+# Install plugins
+/plugin install dwmkerr@dwmkerr-plugins
+/plugin install anthropics@skills
+/plugin install context-engineering-fundamentals@context-engineering-marketplace
+/plugin install skills@claude-toolkit
+```
+
+| Marketplace | Plugin | Description |
+|-------------|--------|-------------|
+| `dwmkerr-plugins` | `dwmkerr` | Personal agents & skills (research, writing, typescript) |
+| `anthropics/skills` | `anthropics` | Official Anthropic skills (docx, pptx, xlsx, pdf) |
+| `context-engineering-marketplace` | `context-engineering-fundamentals` | Context engineering patterns |
+| `claude-toolkit` | `skills` | Claude toolkit utilities |
+
+Discovery: [VoltAgent/awesome-claude-skills](https://github.com/VoltAgent/awesome-claude-skills)
 
 ## Developer Guide
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,5 +1,15 @@
 # CLAUDE.md
 
+# GitHub Repository Access
+
+**CRITICAL**: WebFetch is blocked for GitHub URLs. To explore any GitHub repository:
+
+```bash
+git clone --depth 1 https://github.com/<owner>/<repo> /tmp/<repo>
+```
+
+Then read files from `/tmp/<repo>`. Always use `/tmp` for temporary clones.
+
 # Comments Guidelines
 
 **NEVER add breadcrumb comments** that simply describe what the code does or what it was changed from. Instead, use comments to explain WHY the current approach was chosen.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,16 +1,21 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "includeCoAuthoredBy": false,
-  "alwaysThinkingEnabled": true,
-  "feedbackSurveyState": {
-    "lastShownTime": 1754110186081
-  },
   "env": {
     "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1"
   },
+  "includeCoAuthoredBy": false,
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh",
     "padding": 0
+  },
+  "enabledPlugins": {
+    "dwmkerr@dwmkerr-plugins": true,
+    "context-engineering-fundamentals@context-engineering-marketplace": true,
+    "skills@claude-toolkit": true
+  },
+  "alwaysThinkingEnabled": true,
+  "feedbackSurveyState": {
+    "lastShownTime": 1754110186081
   }
 }

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -16,7 +16,7 @@ Plug 'rakr/vim-one'
 Plug 'neovim/nvim-lspconfig'
 
 Plug 'fatih/vim-go'        " Brutal Golang features
-Plug 'scrooloose/nerdtree' " NerdTree is a tree view for vim.
+Plug 'nvim-tree/nvim-tree.lua' " File explorer tree for neovim.
 Plug 'w0rp/ale'            " Asynchronous Linting Engine.
 Plug 'vim-airline/vim-airline'    " A useful statusbar.
 Plug 'sjl/vitality.vim'    " Nicer cursor, tmux interactions.
@@ -184,28 +184,53 @@ set dir=~/tmp
 " Wildmenu settings, provides much nicer tab completion for commands.
 set wildmenu
 
-" Plugin: NerdTree settings
+" Plugin: nvim-tree settings (requires neovim)
+if has('nvim')
+lua << EOF
+    local ok, nvim_tree = pcall(require, "nvim-tree")
+    if ok then
+        nvim_tree.setup({
+            filters = {
+                dotfiles = false,  -- show hidden files
+                custom = { "^.git$", "^node_modules$", "^.nyc_output$" },
+            },
+            view = {
+                number = true,
+                relativenumber = true,
+            },
+            renderer = {
+                icons = {
+                    show = {
+                        git = false,
+                        folder = false,
+                        file = false,
+                        folder_arrow = true,
+                    },
+                },
+            },
+            update_focused_file = {
+                enable = true,
+            },
+            filesystem_watchers = {
+                enable = true,  -- auto-refresh on file changes
+            },
+        })
+    end
 
-    " Toggle NerdTree with Ctrl+N
-    map <C-n> :NERDTreeToggle<CR>
+    -- Toggle nvim-tree with Ctrl+N
+    vim.keymap.set("n", "<C-n>", "<cmd>NvimTreeToggle<CR>", { silent = true })
 
-    " Show or hide hidden files.
-    let NERDTreeShowHidden=1
-
-    " But still ignore some normally not needed files.
-    let g:NERDTreeIgnore=['\.git$[[dir]]', 'node_modules$[[dir]]', '\.nyc_output$[[dir]]']
-
-    " Ignore the files in our 'wildignore' settings (see higher up in the file).
-    let NERDTreeRespectWildIgnore=1
-
-    " Show the current file in NERDTree.
-    map <leader>t :NERDTreeFind<cr>
+    -- Show current file in nvim-tree
+    vim.keymap.set("n", "<leader>t", "<cmd>NvimTreeFindFile<CR>", { silent = true })
+EOF
+endif
 
 " Plugin: Airline Settings
 
     " Show the buffers in the tabline.
     let g:airline#extensions#tabline#enabled = 1
     let g:airline#extensions#neomake#enabled = 0
+    let g:airline_theme = 'onedark'
 
 " Language Settings
 
@@ -662,10 +687,7 @@ endfunction
 autocmd! User GoyoEnter nested call <SID>goyo_enter()
 autocmd! User GoyoLeave nested call <SID>goyo_leave()
 
-" Toggle line numbers - useful in Nerdtree
-" The autocmd overrides nerdtree defaults - we use number in insert mode and
-" rel otherwise.
-autocmd FileType nerdtree setlocal number relativenumber
+" Toggle line numbers
 let g:last_number_mode = {}
 function! ToggleLineNumbers()
   if &number || &relativenumber


### PR DESCRIPTION
## Summary
- Add GitHub clone-to-tmp instruction in CLAUDE.md (WebFetch blocked for GitHub)
- Document preferred marketplace plugins in README with install commands