### PR TITLE
docs: add trailofbits claude-code-config reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Configuration for Claude Code CLI is managed via symlinks:
 
 To view or edit Claude Code settings, use the `/config` command within Claude Code.
 
+For detailed setup guidance, see: [trailofbits/claude-code-config](https://github.com/trailofbits/claude-code-config)
+
 ### Preferred Plugins
 
 After setup, install preferred marketplace plugins:


### PR DESCRIPTION
## Summary
- Add link to trailofbits/claude-code-config for detailed setup guidance