### PR TITLE
feat: add Claude Code GitHub Action for issue/PR automation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,34 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened, labeled]
+  pull_request_review_comment:
+    types: [created]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude:
+    # Trigger on @claude mentions or the 'claude' label
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude') ||
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(github.event.issue.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "Bash(git status),Bash(git diff),Bash(git log),Bash(npm test),Bash(npm run build),Bash(make *)"

--- a/claude/README.md
+++ b/claude/README.md
@@ -2,6 +2,10 @@
 
 Configuration and setup for [Claude Code](https://claude.ai/code) CLI.
 
+## GitHub Action
+
+Claude Code can run on GitHub issues and PRs via the official `claude-code-action`. Mention `@claude` in an issue or PR comment to trigger it. See [github-action.md](./github-action.md) for setup and usage.
+
 ## Configuration
 
 Configuration files are managed via symlinks from this directory:

--- a/claude/github-action.md
+++ b/claude/github-action.md
@@ -1,0 +1,84 @@
+# Claude Code GitHub Action
+
+Run Claude Code on GitHub issues and PRs. Mention `@claude` or add the `claude` label to trigger it.
+
+## Setup
+
+### 1. Install the Claude GitHub App
+
+Visit https://github.com/apps/claude and install for your account. Select **All repositories** to cover everything, or pick specific repos.
+
+### 2. Add the API key secret
+
+```bash
+# For a single repo
+gh secret set ANTHROPIC_API_KEY --repo dwmkerr/<repo-name>
+
+# For all repos in your account (requires GitHub CLI 2.x)
+gh secret set ANTHROPIC_API_KEY --org dwmkerr --visibility all
+```
+
+### 3. Copy the workflow file
+
+Copy `.github/workflows/claude.yml` from this repo into any repo you want to enable.
+
+## Usage
+
+### From an issue
+
+Create an issue and mention `@claude` in the body:
+
+> @claude add a makefile target for running lint
+
+Claude reads the codebase, implements the change, pushes a branch, and comments with a link to create a PR.
+
+### From a PR comment
+
+Comment on any PR:
+
+> @claude fix the failing test
+
+Claude reads the PR diff, makes changes, and pushes to the branch.
+
+### Using the `claude` label
+
+Add a `claude` label to any issue. Claude picks it up the same as an `@claude` mention.
+
+## How it works
+
+```
+Issue/Comment → GitHub Action triggers → Claude Code runs on the runner
+→ reads codebase → implements → pushes branch → comments with PR link
+```
+
+Claude does NOT auto-create PRs (by design). It pushes commits and gives you a pre-filled link.
+
+## Notifications
+
+Standard GitHub notifications apply:
+- **GitHub mobile app** push notifications
+- **Email** notifications
+- **Slack** via GitHub's Slack integration
+
+## Allowed tools
+
+The workflow restricts Bash to safe commands (`git`, `npm test`, `npm run build`, `make`). Edit the `allowed_tools` field in the workflow to expand this.
+
+## Cost
+
+Typical usage: $0.05-$0.50 per invocation, $10-50/month depending on volume.
+
+## Rolling out to more repos
+
+To add this to another repo, copy the workflow file and set the secret:
+
+```bash
+# Copy workflow
+mkdir -p /path/to/repo/.github/workflows
+cp .github/workflows/claude.yml /path/to/repo/.github/workflows/
+
+# Set secret
+gh secret set ANTHROPIC_API_KEY --repo dwmkerr/<repo-name>
+```
+
+A rollout script for all repos is planned — see the dotfiles README for updates.


### PR DESCRIPTION
## Summary
- Add `.github/workflows/claude.yml` — triggers Claude Code on `@claude` mentions in issues/PRs or the `claude` label
- Add `claude/github-action.md` — setup and usage documentation
- Update `claude/README.md` to link to the new doc
- `ANTHROPIC_API_KEY` secret already set on this repo

## Test plan
- [ ] Create an issue mentioning `@claude` and verify the action triggers
- [ ] Comment `@claude` on a PR and verify it responds
- [ ] Add the `claude` label to an issue and verify it triggers

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/dwmkerr/dotfiles/83?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->