### PR TITLE
chore: add all-contributors attribution

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,35 @@
+{
+  "projectName": "dotfiles",
+  "projectOwner": "dwmkerr",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "contributorsPerLine": 7,
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors-)",
+  "contributors": [
+    {
+      "login": "dwmkerr",
+      "name": "Dave Kerr",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1271997?v=4",
+      "profile": "https://github.com/dwmkerr",
+      "contributions": [
+        "code",
+        "doc",
+        "ideas"
+      ]
+    },
+    {
+      "login": "LoKolbasz",
+      "name": "LoKolbasz",
+      "avatar_url": "https://avatars.githubusercontent.com/LoKolbasz",
+      "profile": "https://github.com/LoKolbasz",
+      "contributions": [
+        "ideas"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Some key features are:
 - [Cheat Sheet - Shell](#cheat-sheet---shell)
 - [Tooling Choices](#tooling-choices)
     - [Vim](#vim)
+- [Contributors](#contributors)
 - [TODO](#todo)
 
 <!-- vim-markdown-toc -->
@@ -478,6 +479,46 @@ These are just some common commands I often forget:
 *Why Vim Plug over Vundle?*
 
 I was impressed enough with the comments on [this post](https://erikzaadi.com/2016/02/11/moving-from-vundle-to-vim-plug/) to make the switch, particularly as [coc](https://github.com/neoclide/coc.nvim) doesn't support Vundle, meaning I had to give Plug a try.
+
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%">
+        <a href="https://github.com/dwmkerr">
+          <img src="https://avatars.githubusercontent.com/u/1271997?v=4" width="100px;" alt="Dave Kerr"/><br />
+          <sub><b>Dave Kerr</b></sub>
+        </a><br />
+        <a href="https://github.com/dwmkerr/dotfiles/commits?author=dwmkerr" title="Code">💻</a>
+        <a href="https://github.com/dwmkerr/dotfiles/commits?author=dwmkerr" title="Documentation">📖</a>
+        <a href="#ideas-dwmkerr" title="Ideas, Planning, & Feedback">🤔</a>
+      </td>
+      <td align="center" valign="top" width="14.28%">
+        <a href="https://github.com/LoKolbasz">
+          <img src="https://avatars.githubusercontent.com/LoKolbasz" width="100px;" alt="LoKolbasz"/><br />
+          <sub><b>LoKolbasz</b></sub>
+        </a><br />
+        <a href="#ideas-LoKolbasz" title="Ideas, Planning, & Feedback">🤔</a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
 ## TODO
 


### PR DESCRIPTION
Adds .all-contributorsrc and a contributors section to README.md, crediting @LoKolbasz for suggesting the MIT licence.

Closes #66

Generated with [Claude Code](https://claude.ai/code)