### PR TITLE
feat: per-identity tmux-resurrect, identity loader, task and vim improvements

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -109,5 +109,6 @@
     }
   },
   "alwaysThinkingEnabled": true,
-  "skipDangerousModePermissionPrompt": true
+  "skipDangerousModePermissionPrompt": true,
+  "effortLevel": "high"
 }

--- a/shell.d/claude.sh
+++ b/shell.d/claude.sh
@@ -1,6 +1,6 @@
 # Inspired by https://github.com/trailofbits/claude-code-config
 
-alias yoloclaude='echo "buckle up..." && claude --dangerously-skip-permissions --chrome'
+alias yoloclaude='echo "buckle up..." && claude --dangerously-skip-permissions --chrome --effort high'
 
 # Run Claude Code against local LM Studio server
 claude-local() {

--- a/shell.functions.d/identity/README.md
+++ b/shell.functions.d/identity/README.md
@@ -1,0 +1,81 @@
+# Identities
+
+Per-terminal git/GitHub identities.
+
+## How it works
+
+Each identity is a small shell file that sets env vars (`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GH_TOKEN`, etc.) for the current shell. Git and `gh` respect these automatically.
+
+## File layout
+
+```
+shell.functions.d/identity/
+  identity.sh                # shell function (sourced via shell.sh)
+  pre-push-identity-guard    # git hook script
+  README.md
+
+~/.shell.private.d/
+  myname.identity            # identity config (secrets — never committed)
+  project-2.identity
+```
+
+Identity `.identity` files live in `~/.shell.private.d/`, not in this directory. They contain secrets (GitHub tokens) and are never committed to git. They are backed up via `make private-files-backup`.
+
+## Creating an identity
+
+Copy an existing `.identity` file and fill in the fields:
+
+```bash
+cp ~/.shell.private.d/dwmkerr.identity ~/.shell.private.d/myname.identity
+```
+
+Fields:
+
+| Field | Description |
+|-------|-------------|
+| `IDENTITY_NAME` | Short name used in commands and prompt |
+| `IDENTITY_GIT_NAME` | Git author/committer name |
+| `IDENTITY_GIT_EMAIL` | Git author/committer email |
+| `IDENTITY_GIT_SIGNING_KEY` | GPG key fingerprint (optional) |
+| `IDENTITY_GH_TOKEN` | GitHub personal access token for `gh` CLI |
+| `IDENTITY_COLOR` | Prompt badge color: red, green, yellow, blue, magenta, cyan |
+| `IDENTITY_ICON` | Emoji shown in `identity list` output |
+| `IDENTITY_BLOCKED_REPOS` | Comma-separated repos/globs to block pushes to |
+| `IDENTITY_HIDE_PS1` | Set to `1` to hide the PS1 badge for this identity |
+
+## Usage
+
+`identity.sh` is sourced automatically via `shell.sh`. Commands:
+
+```bash
+identity list       # show available identities
+identity myname     # load the 'myname' identity
+identity            # show current identity
+identity status     # show identity, git, and GitHub auth details
+identity clear      # unset identity, revert to global gitconfig
+```
+
+## Prompt badge
+
+The PS1 theme shows a colored identity badge on the prompt line. If `identity.sh` isn't sourced, the badge is silently skipped.
+
+## Push guardrails
+
+The `pre-push-identity-guard` script blocks pushes to repos listed in `IDENTITY_BLOCKED_REPOS`. Supports glob patterns like `org-name/*` or `*/repo-name`.
+
+Install per-repo by symlinking to `.git/hooks/pre-push`:
+
+```bash
+ln -sf ~/path/to/dotfiles/shell.functions.d/identity/pre-push-identity-guard \
+    .git/hooks/pre-push
+```
+
+## iTerm2 profiles
+
+Each identity can have an iTerm2 profile in `terminal/iTerm2/`. Profiles run `identity <name> && tmux -L <socket> new-session -A -s <session>` as initial text, giving fully isolated tmux sessions per identity.
+
+## Future ideas
+
+- `.identity.yaml` in repo roots to force/guard identity per-project
+- Global `core.hooksPath` so the push guard works everywhere
+- `identity init` command to scaffold new identities interactively

--- a/shell.functions.d/identity/identity.sh
+++ b/shell.functions.d/identity/identity.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# identity.sh — per-terminal git/GitHub identity manager.
+# Identity data files (*.identity) live in ~/.shell.private.d and are not
+# version-controlled. This loader is safe to track publicly.
+
+_IDENTITIES_DIR="$HOME/.shell.private.d"
+
+_identity_load() {
+    local name="$1"
+    local file="${_IDENTITIES_DIR}/${name}.identity"
+
+    if [ ! -f "$file" ]; then
+        echo "Identity not found: $file" >&2
+        return 1
+    fi
+
+    # Always clear first so no fields leak between identities.
+    _identity_clear_env
+
+    # Source the identity file to get IDENTITY_* vars.
+    source "$file"
+
+    # Export the identity name.
+    export DOTFILES_IDENTITY="$IDENTITY_NAME"
+
+    # Git env vars override global gitconfig per-process.
+    export GIT_AUTHOR_NAME="$IDENTITY_GIT_NAME"
+    export GIT_AUTHOR_EMAIL="$IDENTITY_GIT_EMAIL"
+    export GIT_COMMITTER_NAME="$IDENTITY_GIT_NAME"
+    export GIT_COMMITTER_EMAIL="$IDENTITY_GIT_EMAIL"
+
+    [ -n "$IDENTITY_GIT_SIGNING_KEY" ] && export GIT_COMMITTER_SIGNING_KEY="$IDENTITY_GIT_SIGNING_KEY"
+    [ -n "$IDENTITY_GH_TOKEN" ] && export GH_TOKEN="$IDENTITY_GH_TOKEN"
+    [ -n "$IDENTITY_GIT_SSH_KEY" ] && export GIT_SSH_COMMAND="ssh -i ${IDENTITY_GIT_SSH_KEY/#\~/$HOME} -o IdentitiesOnly=yes -o IdentityAgent=none"
+
+    export TMUX_RESURRECT_DIR="$HOME/.local/share/tmux/resurrect/$IDENTITY_NAME"
+
+    # Store color/icon/blocklist for prompt and hooks.
+    export IDENTITY_COLOR="$IDENTITY_COLOR"
+    export IDENTITY_ICON="$IDENTITY_ICON"
+    export IDENTITY_BLOCKED_REPOS="$IDENTITY_BLOCKED_REPOS"
+}
+
+_identity_clear_env() {
+    unset DOTFILES_IDENTITY
+    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL
+    unset GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+    unset GIT_COMMITTER_SIGNING_KEY
+    unset GH_TOKEN GIT_SSH_COMMAND
+    unset TMUX_RESURRECT_DIR
+    unset "${!IDENTITY_@}"
+}
+
+_identity_clear() {
+    _identity_clear_env
+    echo "Identity cleared. Using global gitconfig defaults."
+}
+
+_identity_show() {
+    if [ -z "$DOTFILES_IDENTITY" ]; then
+        echo "No identity set. Using global gitconfig."
+        return 0
+    fi
+    echo "${IDENTITY_ICON:-?} ${DOTFILES_IDENTITY} (${GIT_AUTHOR_NAME} <${GIT_AUTHOR_EMAIL}>)"
+}
+
+_identity_list() {
+    local file
+    for file in "${_IDENTITIES_DIR}"/*.identity; do
+        [ -e "$file" ] || continue
+        local name
+        name="$(basename "$file" .identity)"
+        # Source into a subshell to read fields without polluting env.
+        local icon git_name git_email
+        icon="$(source "$file" && echo "$IDENTITY_ICON")"
+        git_name="$(source "$file" && echo "$IDENTITY_GIT_NAME")"
+        git_email="$(source "$file" && echo "$IDENTITY_GIT_EMAIL")"
+        if [ "$name" = "$DOTFILES_IDENTITY" ]; then
+            echo "* ${icon} ${name}  ${git_name} <${git_email}>"
+        else
+            echo "  ${icon} ${name}  ${git_name} <${git_email}>"
+        fi
+    done
+}
+
+# PS1 badge — only shown for non-default identities.
+_identity_info() {
+    [ -z "$DOTFILES_IDENTITY" ] && return
+    [ "${IDENTITY_HIDE_PS1:-0}" = "1" ] && return
+    local reset=$(tput sgr0)
+    local bold=$(tput bold)
+    local color
+    case "${IDENTITY_COLOR:-white}" in
+        red)     color=$(tput setaf 1) ;;
+        green)   color=$(tput setaf 2) ;;
+        yellow)  color=$(tput setaf 3) ;;
+        blue)    color=$(tput setaf 4) ;;
+        magenta) color=$(tput setaf 5) ;;
+        cyan)    color=$(tput setaf 6) ;;
+        *)       color=$(tput setaf 7) ;;
+    esac
+    echo "${bold}${color}${DOTFILES_IDENTITY}${reset} "
+}
+
+_identity_status() {
+    echo "=== Identity ==="
+    if [ -n "$DOTFILES_IDENTITY" ]; then
+        echo "  DOTFILES_IDENTITY=$DOTFILES_IDENTITY"
+    else
+        echo "  No identity set"
+    fi
+
+    echo ""
+    echo "=== Git (env vars override gitconfig) ==="
+    echo "  \$ echo \$GIT_AUTHOR_NAME"
+    echo "  ${GIT_AUTHOR_NAME:-(not set)}"
+    echo "  \$ echo \$GIT_AUTHOR_EMAIL"
+    echo "  ${GIT_AUTHOR_EMAIL:-(not set)}"
+    echo "  \$ git config user.name"
+    echo "  $(git config user.name 2>/dev/null || echo '(not set)')"
+    echo "  \$ git config user.email"
+    echo "  $(git config user.email 2>/dev/null || echo '(not set)')"
+
+    echo ""
+    echo "=== GitHub ==="
+    echo "  \$ echo \$GH_TOKEN"
+    if [ -n "$GH_TOKEN" ]; then
+        echo "  ${GH_TOKEN:0:8}..."
+    else
+        echo "  (not set)"
+    fi
+    echo "  \$ gh auth status"
+    gh auth status 2>&1 | sed 's/^/  /'
+
+    if [ -n "$IDENTITY_BLOCKED_REPOS" ]; then
+        echo ""
+        echo "=== Blocked repos ==="
+        echo "  ${IDENTITY_BLOCKED_REPOS}"
+    fi
+}
+
+identity() {
+    local cmd="${1:-}"
+
+    case "$cmd" in
+        "")      _identity_show ;;
+        list)    _identity_list ;;
+        clear)   _identity_clear ;;
+        status)  _identity_status ;;
+        *)       _identity_load "$cmd" && _identity_show ;;
+    esac
+}
+
+# Auto-load identity if DOTFILES_IDENTITY is already set (e.g. from iTerm profile).
+if [ -n "$DOTFILES_IDENTITY" ]; then
+    _identity_load "$DOTFILES_IDENTITY"
+fi

--- a/shell.functions.d/identity/pre-push-identity-guard
+++ b/shell.functions.d/identity/pre-push-identity-guard
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# pre-push-identity-guard — rejects pushes to repos blocked for current identity.
+# Install: symlink to .git/hooks/pre-push in repos you want to protect.
+
+# No identity set — allow push.
+if [ -z "$DOTFILES_IDENTITY" ]; then
+    exit 0
+fi
+
+# No blocklist — allow push.
+if [ -z "$IDENTITY_BLOCKED_REPOS" ]; then
+    exit 0
+fi
+
+remote_url="$2"
+
+# Extract owner/repo from remote URL.
+# Handles: git@github.com:owner/repo.git, https://github.com/owner/repo.git
+repo_path=$(echo "$remote_url" | sed -E 's#(git@|https://)([^:/]+)[:/]##; s/\.git$//')
+
+IFS=',' read -ra blocked <<< "$IDENTITY_BLOCKED_REPOS"
+for entry in "${blocked[@]}"; do
+    entry=$(echo "$entry" | xargs) # trim whitespace
+    # Glob patterns supported (e.g. "jspec*", "dwmkerr/*", "*/dotfiles").
+    if [[ "$repo_path" == $entry ]]; then
+        echo "BLOCKED: identity '${DOTFILES_IDENTITY}' cannot push to '${repo_path}'" >&2
+        echo "Blocked repos for this identity: ${IDENTITY_BLOCKED_REPOS}" >&2
+        exit 1
+    fi
+done
+
+exit 0

--- a/shell.functions.d/task.sh
+++ b/shell.functions.d/task.sh
@@ -6,32 +6,62 @@ task() {
     echo "  ${name} <task-name>    create or switch to a task"
     echo "  ${name}                list tasks"
     echo "  ${name} -r <pattern>   resume a task in a new tmux window"
-    echo "  ${name} -d <pattern>   delete a task and its folder"
-    echo "  ${name} --complete     archive the current task folder"
+    echo "  ${name} --resume <pattern>  resume a task; right pane runs 'yoloclaude -c'"
+    echo "  ${name} -d [pattern]   move a task to recycle bin (current task if no pattern)"
+    echo "  ${name} --delete [pattern]  move a task to recycle bin"
+    echo "  ${name} --discard [pattern] move a task to recycle bin"
+    echo "  ${name} --complete [pattern] move a task to completed (current task if no pattern)"
     return 0
   fi
 
-  # --- Complete (archive) current task ---
+  # --- Complete task (move to 00-completed) ---
   if [[ "$1" == "--complete" ]]; then
-    local current_dir="$PWD"
-    local current_name="$(basename "$current_dir")"
-    local parent_dir="$(dirname "$current_dir")"
+    shift
+    local target=""
+    local label=""
 
-    # Verify we're in a task folder under ~/tasks.
-    if [[ "$parent_dir" != "$HOME/tasks" ]] || [[ "$current_name" != task-* ]]; then
-      echo "error: not in a task folder (~/tasks/task-*)"
-      return 1
+    if [[ -z "$1" || "$1" == "." ]]; then
+      # Current task
+      local current_dir="$PWD"
+      local current_name="$(basename "$current_dir")"
+      local parent_dir="$(dirname "$current_dir")"
+      if [[ "$parent_dir" != "$HOME/tasks" ]] || [[ "$current_name" != task-* ]]; then
+        echo "error: not in a task folder (~/tasks/task-*)"
+        return 1
+      fi
+      target="$current_dir"
+      label="$current_name"
+    else
+      # Pattern match
+      local pattern="$*"
+      local matches=()
+      for d in ~/tasks/task-*; do
+        [[ -d "$d" ]] && [[ "$(basename "$d")" == *"${pattern}"* ]] && matches+=("$d")
+      done
+      if [[ ${#matches[@]} -eq 0 ]]; then
+        echo "no task matching '${pattern}'"
+        return 1
+      elif [[ ${#matches[@]} -gt 1 ]]; then
+        echo "multiple matches — be more specific:"
+        for d in "${matches[@]}"; do echo "  $(basename "$d")"; done
+        return 1
+      fi
+      target="${matches[0]}"
+      label="$(basename "$target")"
     fi
 
-    local archive_dir="$HOME/tasks/zz-archive"
-    mkdir -p "$archive_dir"
-    mv "$current_dir" "$archive_dir/"
-    echo -e "archived \e[1;32m${current_name}\e[0m → zz-archive/"
+    local completed_dir="$HOME/tasks/00-completed"
+    mkdir -p "$completed_dir"
+    mv "$target" "$completed_dir/"
+    echo -e "completed \e[1;32m${label}\e[0m → 00-completed/"
+    tmux kill-window -t "🟠 ${label}" 2>/dev/null
 
-    if [[ -n "${TMUX}" ]]; then
-      tmux kill-window
-    else
-      cd ~/tasks
+    if [[ "$PWD" == "$target" ]]; then
+      if [[ -n "${TMUX}" ]]; then
+        tmux kill-window
+      else
+        cd ~/tasks
+      fi
     fi
     return 0
   fi
@@ -58,11 +88,63 @@ task() {
     return 0
   fi
 
-  # --- Delete task ---
-  if [[ "$1" == "-d" ]]; then
+  # --- Delete / discard task (move to recycle bin) ---
+  if [[ "$1" == "-d" || "$1" == "--delete" || "$1" == "--discard" ]]; then
+    shift
+    local target=""
+    local label=""
+
+    if [[ -z "$1" || "$1" == "." ]]; then
+      # Current task
+      local current_dir="$PWD"
+      local current_name="$(basename "$current_dir")"
+      local parent_dir="$(dirname "$current_dir")"
+      if [[ "$parent_dir" != "$HOME/tasks" ]] || [[ "$current_name" != task-* ]]; then
+        echo "error: not in a task folder (~/tasks/task-*)"
+        return 1
+      fi
+      target="$current_dir"
+      label="$current_name"
+    else
+      # Pattern match
+      local pattern="$*"
+      local matches=()
+      for d in ~/tasks/task-*; do
+        [[ -d "$d" ]] && [[ "$(basename "$d")" == *"${pattern}"* ]] && matches+=("$d")
+      done
+      if [[ ${#matches[@]} -eq 0 ]]; then
+        echo "no task matching '${pattern}'"
+        return 1
+      elif [[ ${#matches[@]} -gt 1 ]]; then
+        echo "multiple matches — be more specific:"
+        for d in "${matches[@]}"; do echo "  $(basename "$d")"; done
+        return 1
+      fi
+      target="${matches[0]}"
+      label="$(basename "$target")"
+    fi
+
+    local recycle_dir="$HOME/tasks/00-recycle-bin"
+    mkdir -p "$recycle_dir"
+    mv "$target" "$recycle_dir/"
+    tmux kill-window -t "🟠 ${label}" 2>/dev/null
+    echo -e "discarded \e[1;31m${label}\e[0m → 00-recycle-bin/"
+
+    if [[ "$PWD" == "$target" ]]; then
+      if [[ -n "${TMUX}" ]]; then
+        tmux kill-window
+      else
+        cd ~/tasks
+      fi
+    fi
+    return 0
+  fi
+
+  # --- Resume task (with yoloclaude -c on right pane) ---
+  if [[ "$1" == "--resume" ]]; then
     shift
     if [[ -z "$1" ]]; then
-      echo "error: specify a pattern to match, e.g. task -d 02"
+      echo "error: specify a pattern to match, e.g. task --resume 01"
       return 1
     fi
     local pattern="$*"
@@ -80,9 +162,10 @@ task() {
     fi
     local target="${matches[0]}"
     local label="$(basename "$target")"
-    rm -rf "$target"
-    tmux kill-window -t "🟠 ${label}" 2>/dev/null
-    echo -e "deleted \e[1;31m${label}\e[0m"
+    tmux new-window -n "🟠 ${label}" -c "${target}"
+    tmux split-window -h -c "${target}" 'yoloclaude -c'
+    tmux select-pane -L
+    echo -e "resumed \e[1;32m${label}\e[0m"
     return 0
   fi
 
@@ -162,17 +245,17 @@ _task_completions() {
   done
 
   if [ -n "${ZSH_VERSION:-}" ]; then
-    local flags=('-h' '-r' '-d' '--complete')
+    local flags=('-h' '-r' '--resume' '-d' '--delete' '--discard' '--complete')
     case "${words[2]}" in
-      -r|-d) compadd -- "${tasks[@]}" ;;
+      -r|--resume|-d|--delete|--discard) compadd -- "${tasks[@]}" ;;
       *)     compadd -- "${flags[@]}" "${tasks[@]}" ;;
     esac
   else
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
     case "$prev" in
-      -r|-d) COMPREPLY=($(compgen -W "${tasks[*]}" -- "$cur")) ;;
-      *)     COMPREPLY=($(compgen -W "-h -r -d --complete ${tasks[*]}" -- "$cur")) ;;
+      -r|--resume|-d|--delete|--discard) COMPREPLY=($(compgen -W "${tasks[*]}" -- "$cur")) ;;
+      *)     COMPREPLY=($(compgen -W "-h -r --resume -d --delete --discard --complete ${tasks[*]}" -- "$cur")) ;;
     esac
   fi
 }

--- a/shell.sh
+++ b/shell.sh
@@ -102,7 +102,7 @@ elif [ -n "$ZSH_VERSION" ]; then
 fi
 
 # Import all shell functions and shell.d files.
-for file in $HOME/.shell.functions.d/*; do
+for file in $HOME/.shell.functions.d/*.sh $HOME/.shell.functions.d/*/*.sh; do
     [ -e "$file" ] || continue
     source "$file"
 done
@@ -114,7 +114,7 @@ done
 # Import everything from the .shell.private.d folder.
 if [ -d $HOME/.shell.private.d ]; then
     for file in $HOME/.shell.private.d/*; do
-        [ -e "$file" ] || continue
+        [ -f "$file" ] || continue
         source "$file"
     done
 fi

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -146,6 +146,11 @@ set -g status-justify left
 set -g status-bg default
 set -g status-interval 2
 
+# Resolve per-identity resurrect dir to a literal path before tpm loads, so
+# continuum sees the right value at auto-restore time. run-shell is required
+# because @resurrect-dir does not expand env vars — only ~, $HOME, $HOSTNAME.
+run-shell 'tmux set-option -g @resurrect-dir "${TMUX_RESURRECT_DIR:-$HOME/.local/share/tmux/resurrect}"'
+
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -59,6 +59,8 @@ Plug 'heavenshell/vim-jsdoc', {
 "   Note: language support is via vim-polyglot.
 Plug 'mzlogin/vim-markdown-toc' " Build a TOC for markdown.
 Plug 'iamcco/markdown-preview.nvim', { 'do': { -> mkdp#util#install() }, 'for': ['markdown', 'vim-plug']}
+Plug 'nvim-treesitter/nvim-treesitter', {'do': ':TSUpdate'}
+Plug 'MeanderingProgrammer/render-markdown.nvim'
 
 " Plugins for writing with focus.
 Plug 'junegunn/goyo.vim'        " Go into distraction free mode (:Gojo)
@@ -162,6 +164,12 @@ set wildignore+=*.pyc,*.o,*.obj,*.svn,*.swp,*.class,*.hg,*.DS_Store,*.min.*
     \}
     " let g:onedark_terminal_italics=1
     colorscheme onedark
+
+    " Subtle spell highlights - undercurl only, no text color change
+    hi SpellBad   cterm=undercurl gui=undercurl guisp=#e06c75 ctermbg=NONE guibg=NONE guifg=NONE ctermfg=NONE
+    hi SpellCap   cterm=undercurl gui=undercurl guisp=#61afef ctermbg=NONE guibg=NONE guifg=NONE ctermfg=NONE
+    hi SpellRare  cterm=undercurl gui=undercurl guisp=#c678dd ctermbg=NONE guibg=NONE guifg=NONE ctermfg=NONE
+    hi SpellLocal cterm=undercurl gui=undercurl guisp=#e5c07b ctermbg=NONE guibg=NONE guifg=NONE ctermfg=NONE
 
 " Cursor Configuration
    set guicursor=n-c-v:block-nCursor,i-ci:ver100-iCursor-blinkon200-blinkoff150
@@ -462,6 +470,35 @@ if has('nvim')
         --    rg_opts = "--color=always --smart-case -g '!{.git,node_modules}/'",
         --  },
         --})
+EOF
+endif
+
+" render-markdown.nvim: inline markdown rendering with <Leader>md toggle.
+if has('nvim')
+    lua <<EOF
+        require('nvim-treesitter.config').setup({
+            ensure_installed = { 'markdown', 'markdown_inline' },
+            highlight = { enable = true },
+        })
+        -- Heading colors matching render-markdown.nvim wiki demo
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH1', { fg = '#f0c674', bold = true })
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH1Bg', { fg = '#d4d4d4', bg = '#363a44', bold = true })
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH2', { fg = '#e5c07b', bold = true })
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH2Bg', { fg = '#d4d4d4', bg = '#3a3530', bold = true })
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH3', { fg = '#98c379', bold = true })
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH3Bg', { fg = '#d4d4d4', bg = '#2e3e30', bold = true })
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH4', { fg = '#56b6c2', bold = true })
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH4Bg', { fg = '#d4d4d4', bg = '#253540', bold = true })
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH5', { fg = '#c678dd', bold = true })
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH5Bg', { fg = '#d4d4d4', bg = '#352e40', bold = true })
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH6', { fg = '#b070c0', bold = true })
+        vim.api.nvim_set_hl(0, 'RenderMarkdownH6Bg', { fg = '#d4d4d4', bg = '#332e3e', bold = true })
+        require('render-markdown').setup({
+            anti_conceal = { enabled = false },
+        })
+        vim.keymap.set('n', '<Leader>md', function()
+            require('render-markdown').toggle()
+        end, { desc = 'Toggle markdown rendering' })
 EOF
 endif
 


### PR DESCRIPTION
## Summary
- Per-identity tmux-resurrect: each identity gets its own save/restore dir via `TMUX_RESURRECT_DIR` env var and `run-shell` in tmux.conf
- Move `identity.sh` and `pre-push-identity-guard` from gitignored `identities/` to tracked `shell.functions.d/identity/`
- Support `shell.functions.d` subfolders by sourcing `*.sh` + `*/*.sh`
- Fix `shell.private.d` sourcing to skip directories (fixes `source: is a directory` error)
- Task function: delete/discard moves to recycle bin instead of `rm -rf`, `--complete` accepts pattern, `--resume` opens yoloclaude in right pane
- Vim: add render-markdown.nvim with treesitter, subtle spell undercurl highlights
- Claude: set effort level high, add `--effort high` to yoloclaude alias