### PR TITLE
fix: repair fresh-machine setup for bash + iTerm + tmux

### DIFF
--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -1,0 +1,3 @@
+# Login shells read this file; source .bashrc so both login and non-login
+# interactive shells get the same configuration.
+[ -f ~/.bashrc ] && source ~/.bashrc

--- a/bash/bashrc
+++ b/bash/bashrc
@@ -1,0 +1,2 @@
+# Source my personal (github.com/dwmkerr/dotfiles) configuration.
+[ -r ~/.shell.sh ] && source ~/.shell.sh

--- a/makefile
+++ b/makefile
@@ -11,11 +11,14 @@ link: # Creates symbolic links.
 	ln -sfn ${PWD}/shell.functions.d ~/.shell.functions.d
 	ln -sfn ${PWD}/shell.private.d ~/.shell.private.d
 	ln -sfn ${PWD}/vim/vimrc ~/.vimrc
+	mkdir -p ~/.vim ~/.config/nvim
 	ln -sfn ${PWD}/vim/coc-settings.json ~/.vim/coc-settings.json
 	ln -sfn ${PWD}/vim/coc-settings.json ~/.config/nvim/coc-settings.json
 	ln -sfn ${PWD}/tmux/tmux.conf ~/.tmux.conf
 	ln -sfn ${PWD}/ack/ackrc ~/.ackrc
 	ln -sfn ${PWD}/zsh/zshrc ~/.zshrc
+	ln -sfn ${PWD}/bash/bashrc ~/.bashrc
+	ln -sfn ${PWD}/bash/bash_profile ~/.bash_profile
 	ln -sfn ${PWD}/ag/ignore ~/.ignore
 	mkdir -p ~/Library/Application\ Support/Code/User/ && ln -sfn ${PWD}/VSCode/settings.json  ~/Library/Application\ Support/Code/User/settings.json || echo "error: can't link VSCode settings.json"
 	mkdir -p ~/.claude

--- a/shell.d/ag-fzf.sh
+++ b/shell.d/ag-fzf.sh
@@ -7,6 +7,10 @@ if type ag >/dev/null 2>&1; then
     export FZF_DEFAULT_COMMAND='ag --path-to-ignore ~/.ignore -g ""'
 fi
 
-# If we have fzf config, source it.
-[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+# If we have fzf config, source the variant for the current shell.
+if [ -n "$ZSH_VERSION" ]; then
+    [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+elif [ -n "$BASH_VERSION" ]; then
+    [ -f ~/.fzf.bash ] && source ~/.fzf.bash
+fi
 

--- a/shell.functions.d/set_ps1.sh
+++ b/shell.functions.d/set_ps1.sh
@@ -138,8 +138,13 @@ set_ps1() {
 
     esac
 
-    # If we are in Z-Shell convert the PS1 to use Z-Shell format.
-    [ -n "$ZSH_VERSION" ] && PS1=$(_to_zsh "$PS1")
+    # If we are in Z-Shell convert the PS1 to use Z-Shell format. PROMPT_SUBST
+    # is required for $(...) in PS1 to be evaluated in zsh (bash does this by
+    # default).
+    if [ -n "$ZSH_VERSION" ]; then
+        setopt PROMPT_SUBST
+        PS1=$(_to_zsh "$PS1")
+    fi
 }
 
 # Build a string that shows:

--- a/shell.sh
+++ b/shell.sh
@@ -77,7 +77,7 @@ export LANG=en_US.UTF-8
 # https://askubuntu.com/questions/1021553/can-i-check-if-the-terminal-was-started-by-visual-studio-code
 # Similar for Android:
 # https://youtrack.jetbrains.com/articles/IDEA-A-19/Shell-Environment-Loading
-if [ -x "$(command -v "tmux")" ]; then
+if command -v tmux >/dev/null 2>&1; then
     IS_IN_IDE=0
     if [[ "$TERM_PROGRAM" == "vscode" || -n "$INTELLIJ_ENVIRONMENT_READER" ]]; then
         IS_IN_IDE=1
@@ -111,12 +111,13 @@ for file in $HOME/.shell.d/*; do
     source "$file"
 done
 
-# Import everything from the .shell.private.d folder.
-if [ -d $HOME/.shell.private.d ]; then
-    for file in $HOME/.shell.private.d/*; do
-        [ -f "$file" ] || continue
-        source "$file"
-    done
+# Import everything from the .shell.private.d folder. Use find to avoid zsh's
+# "no matches found" error when the glob matches nothing (e.g. when the only
+# entry is a hidden file like .gitignore).
+if [ -d "$HOME/.shell.private.d" ]; then
+    while IFS= read -r file; do
+        [ -f "$file" ] && source "$file"
+    done < <(find "$HOME/.shell.private.d" -maxdepth 1 -type f ! -name '.*' 2>/dev/null)
 fi
 
 # If we have a .private folder, source everything in it. This is useful for

--- a/terminal/iTerm2/dwmkerr-agent.json
+++ b/terminal/iTerm2/dwmkerr-agent.json
@@ -349,7 +349,7 @@
   "Smart Cursor Color (Dark)": false,
   "BM Growl": true,
   "Prompt Before Closing 2": false,
-  "Command": "/opt/homebrew/Cellar/bash/5.2.37/bin/bash",
+  "Command": "/opt/homebrew/bin/bash",
   "Initial Text": "identity agent && tmux -L agent new-session -A -s dwmkerr-agent",
   "Smart Cursor Color (Light)": false,
   "Use Bright Bold (Light)": true,
@@ -419,7 +419,7 @@
   "Default Bookmark": "No",
   "Bound Hosts": [],
   "Minimum Contrast (Dark)": 0,
-  "Custom Command": "No",
+  "Custom Command": "Yes",
   "Foreground Color (Light)": {
     "Red Component": 0.67058825492858887,
     "Color Space": "sRGB",

--- a/terminal/iTerm2/dwmkerr.json
+++ b/terminal/iTerm2/dwmkerr.json
@@ -349,7 +349,8 @@
   "Smart Cursor Color (Dark)" : false,
   "BM Growl" : true,
   "Prompt Before Closing 2" : false,
-  "Command" : "\/opt\/homebrew\/Cellar\/bash\/5.2.37\/bin\/bash",
+  "Command" : "\/opt\/homebrew\/bin\/bash",
+  "Initial Text" : "tmux -L dwmkerr new-session -A -s dwmkerr",
   "Smart Cursor Color (Light)" : false,
   "Use Bright Bold (Light)" : true,
   "Use Selected Text Color (Light)" : true,
@@ -420,7 +421,7 @@
 
   ],
   "Minimum Contrast (Dark)" : 0,
-  "Custom Command" : "No",
+  "Custom Command" : "Yes",
   "Foreground Color (Light)" : {
     "Red Component" : 0.67058825492858887,
     "Color Space" : "sRGB",

--- a/terminal/iTerm2/gdog.json
+++ b/terminal/iTerm2/gdog.json
@@ -349,7 +349,7 @@
   "Smart Cursor Color (Dark)": false,
   "BM Growl": true,
   "Prompt Before Closing 2": false,
-  "Command": "/opt/homebrew/Cellar/bash/5.2.37/bin/bash",
+  "Command": "/opt/homebrew/bin/bash",
   "Initial Text": "identity gdog && tmux -L gdog new-session -A -s gdog",
   "Smart Cursor Color (Light)": false,
   "Use Bright Bold (Light)": true,
@@ -419,7 +419,7 @@
   "Default Bookmark": "No",
   "Bound Hosts": [],
   "Minimum Contrast (Dark)": 0,
-  "Custom Command": "No",
+  "Custom Command": "Yes",
   "Foreground Color (Light)": {
     "Red Component": 0.67058825492858887,
     "Color Space": "sRGB",

--- a/terminal/iTerm2/iterm-profile-dwmkerr-recording.json
+++ b/terminal/iTerm2/iterm-profile-dwmkerr-recording.json
@@ -372,7 +372,7 @@
     "Alpha Component" : 1,
     "Green Component" : 1
   },
-  "Command" : "\/opt\/homebrew\/Cellar\/bash\/5.2.37\/bin\/bash  --noprofile --norc -c 'export TMUX=\"ignore\"; \/opt\/homebrew\/Cellar\/bash\/5.2.37\/bin\/bash --init-file <(echo \" source ~\/.shell.sh; clear;\")'",
+  "Command" : "\/opt\/homebrew\/bin\/bash  --noprofile --norc -c 'export TMUX=\"ignore\"; \/opt\/homebrew\/bin\/bash --init-file <(echo \" source ~\/.shell.sh; clear;\")'",
   "Minimum Contrast (Light)" : 0,
   "Character Encoding" : 4,
   "Cursor Boost (Light)" : 0,


### PR DESCRIPTION
- Makefile: mkdir -p ~/.vim ~/.config/nvim before coc-settings symlinks; add ~/.bashrc and ~/.bash_profile symlinks
- bash/bashrc, bash/bash_profile: minimal rc files that source ~/.shell.sh, mirroring the zsh/zshrc pattern so bash and zsh share config
- shell.sh: replace glob loop for .shell.private.d with find (avoids zsh "no matches found" when the dir has only hidden files); fix tmux detection that was tripped by the tmux alias set a few lines earlier
- shell.d/ag-fzf.sh: source .fzf.bash in bash, .fzf.zsh in zsh (the unconditional .fzf.zsh source was a bash syntax error)
- shell.functions.d/set_ps1.sh: setopt PROMPT_SUBST in zsh so \$(...) in PS1 is evaluated
- terminal/iTerm2/*.json: Custom Command=Yes (was No, iTerm was using login shell), stable /opt/homebrew/bin/bash path (was versioned Cellar path); dwmkerr profile gets Initial Text with isolated tmux socket, matching the dwmkerr-agent and gdog pattern