### PR TITLE
fix: use portable unset in identity loader for zsh compatibility

### DIFF
--- a/shell.functions.d/identity/identity.sh
+++ b/shell.functions.d/identity/identity.sh
@@ -48,7 +48,11 @@ _identity_clear_env() {
     unset GIT_COMMITTER_SIGNING_KEY
     unset GH_TOKEN GIT_SSH_COMMAND
     unset TMUX_RESURRECT_DIR
-    unset "${!IDENTITY_@}"
+    # Enumerate IDENTITY_* explicitly. `${!IDENTITY_@}` is bash-only and
+    # breaks under zsh with "bad substitution".
+    unset IDENTITY_NAME IDENTITY_GIT_NAME IDENTITY_GIT_EMAIL \
+          IDENTITY_GIT_SIGNING_KEY IDENTITY_GH_TOKEN IDENTITY_GIT_SSH_KEY \
+          IDENTITY_COLOR IDENTITY_ICON IDENTITY_BLOCKED_REPOS IDENTITY_HIDE_PS1
 }
 
 _identity_clear() {


### PR DESCRIPTION
## Summary
- `_identity_clear_env` used `unset \"\${!IDENTITY_@}\"`, a bash-only indirect expansion. Under zsh this raises `bad substitution` and blocks the `identity` command entirely (e.g. `identity dwmkerr` fails immediately).
- Replace with an explicit `unset` of the known `IDENTITY_*` schema fields. Verified syntax under both `bash -n` and `zsh -n`.