### PR TITLE
perf: lazy nvm + statusline/identity tweaks

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -98,7 +98,8 @@
     "dwmkerr-toolkit@dwmkerr-claude-toolkit": true,
     "protocols@claude-toolkit": true,
     "gopls-lsp@claude-plugins-official": true,
-    "git-workforest@git-workforest": true
+    "git-workforest@git-workforest": true,
+    "caveman@caveman": true
   },
   "extraKnownMarketplaces": {
     "git-workforest": {
@@ -106,9 +107,14 @@
         "source": "github",
         "repo": "dwmkerr/git-workforest"
       }
+    },
+    "caveman": {
+      "source": {
+        "source": "github",
+        "repo": "JuliusBrussee/caveman"
+      }
     }
   },
   "alwaysThinkingEnabled": true,
-  "skipDangerousModePermissionPrompt": true,
-  "effortLevel": "high"
+  "skipDangerousModePermissionPrompt": true
 }

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -3,9 +3,10 @@
 # Read JSON input from stdin
 input=$(cat)
 
-# Extract current directory and model name using jq
+# Extract current directory, model name, and effort level using jq.
 CURRENT_DIR=$(echo "$input" | jq -r '.workspace.current_dir')
 MODEL_NAME=$(echo "$input" | jq -r '.model.display_name')
+EFFORT=$(echo "$input" | jq -r '.effort.level // empty')
 
 # Colors using ANSI codes directly
 reset=$'\e[0m'
@@ -14,6 +15,7 @@ fg_blue=$'\e[34m'
 fg_green=$'\e[32m'
 fg_grey=$'\e[90m'
 fg_purple=$'\e[35m'
+fg_lightblue=$'\e[94m'
 # Context colors based on usage thresholds
 ctx_green=$'\e[92m'      # 0-30% used
 ctx_yellow=$'\e[93m'     # 30-50% used
@@ -60,13 +62,17 @@ if [ "$usage" != "null" ] && [ "$context_size" != "null" ] && [ "$context_size" 
         ctx_icon="🔥"
     fi
 
-    context_display=" ${fg_grey}|${reset} ${ctx_color}${ctx_icon}${remaining}%${reset} ${fg_grey}context left${reset}"
+    context_display=" ${fg_grey}|${reset} ${ctx_color}${ctx_icon}${remaining}%${reset} ${fg_grey}context${reset}"
 fi
 
-# Build model display
+# Build model display. Faint effort level (e.g. "high", "max", "vhigh")
+# trails the model name with no separator, just colour.
 model_display=""
 if [ -n "$MODEL_NAME" ] && [ "$MODEL_NAME" != "null" ]; then
     model_display=" ${fg_grey}|${reset} ${fg_purple}${MODEL_NAME}${reset}"
+    if [ -n "$EFFORT" ]; then
+        model_display="${model_display} ${fg_lightblue}${EFFORT}${reset}"
+    fi
 fi
 
 # Identity badge

--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ link: # Creates symbolic links.
 	ln -sfn ${PWD}/bash/bashrc ~/.bashrc
 	ln -sfn ${PWD}/bash/bash_profile ~/.bash_profile
 	ln -sfn ${PWD}/ag/ignore ~/.ignore
-	mkdir -p ~/Library/Application\ Support/Code/User/ && ln -sfn ${PWD}/VSCode/settings.json  ~/Library/Application\ Support/Code/User/settings.json || echo "error: can't link VSCode settings.json"
+	mkdir -p ~/Library/Application\ Support/Code/User/ && ln -sfn ${PWD}/vscode/settings.json  ~/Library/Application\ Support/Code/User/settings.json || echo "error: can't link VSCode settings.json"
 	mkdir -p ~/.claude
 	ln -sfn ${PWD}/claude/CLAUDE.md ~/.claude/CLAUDE.md || echo "error: can't link CLAUDE.md"
 	ln -sfn ${PWD}/claude/settings.json ~/.claude/settings.json || echo "error: can't link claude settings.json"

--- a/shell.d/node.sh
+++ b/shell.d/node.sh
@@ -1,44 +1,35 @@
-# Load NVM.
+# Lazy NVM: preset PATH so node/npm/npx work immediately without sourcing
+# nvm.sh (~1.5s cost). Vim/nvim and coc.nvim find node binary via PATH.
+# Only nvm function itself is lazy-loaded since it has no binary.
 export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
 
-# Load NVM completion.
-if [ -n "$BASH_VERSION" ]; then
-    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-fi
+# Resolve default version (alias chain may end at glob like lts/* — pick newest installed).
+_nvm_default_bin() {
+    local target version
+    [ -d "$NVM_DIR/alias" ] || return 1
+    target=$(cat "$NVM_DIR/alias/default" 2>/dev/null) || return 1
+    while [ -f "$NVM_DIR/alias/$target" ]; do
+        target=$(cat "$NVM_DIR/alias/$target")
+    done
+    if [ "$target" = "lts/*" ] || [ -z "$target" ]; then
+        version=$(ls -1 "$NVM_DIR/versions/node" 2>/dev/null | sort -V | tail -1)
+    else
+        version="$target"
+    fi
+    [ -d "$NVM_DIR/versions/node/$version/bin" ] && echo "$NVM_DIR/versions/node/$version/bin"
+}
 
-# Note: the 'lazy load' method below *does* make things faster. However, if
-# another program needs node (such as vim, which might use it in plugins) then
-# calls to node will fail. So I'm reverting to eager behaviour above.
+_nvm_bin=$(_nvm_default_bin)
+[ -n "$_nvm_bin" ] && export PATH="$_nvm_bin:$PATH"
+unset -f _nvm_default_bin
+unset _nvm_bin
 
-# This is a way to speed up nvm, lazy loading it as needed. Note that this comes
-# from:
-#   https://til-engineering.nulogy.com/Slow-Terminal-Startup-Tip-Lazy-Load-NVM/
-# lazynvm() {
-#   unset -f nvm node npm npx
-#   export NVM_DIR=~/.nvm
-#   [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
-#   if [ -f "$NVM_DIR/bash_completion" ]; then
-#     [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" # This loads nvm bash_completion
-#   fi
-# }
-
-# nvm() {
-#   lazynvm 
-#   nvm $@
-# }
- 
-# node() {
-#   lazynvm
-#   node $@
-# }
- 
-# npm() {
-#   lazynvm
-#   npm $@
-# }
-
-# npx() {
-#   lazynvm
-#   npx $@
-# }
+# Lazy stub: nvm has no binary, so we stub it. First invocation sources real nvm.
+nvm() {
+    unset -f nvm
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+    if [ -n "$BASH_VERSION" ]; then
+        [ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"
+    fi
+    nvm "$@"
+}

--- a/terminal/iTerm2/dwmkerr.json
+++ b/terminal/iTerm2/dwmkerr.json
@@ -350,7 +350,10 @@
   "BM Growl" : true,
   "Prompt Before Closing 2" : false,
   "Command" : "\/opt\/homebrew\/bin\/bash",
-  "Initial Text" : "tmux -L dwmkerr new-session -A -s dwmkerr",
+  "Initial Text" : "identity dwmkerr && tmux -L dwmkerr new-session -A -s dwmkerr",
+  "Environment" : {
+    "DOTFILES_IDENTITY" : "dwmkerr"
+  },
   "Smart Cursor Color (Light)" : false,
   "Use Bright Bold (Light)" : true,
   "Use Selected Text Color (Light)" : true,

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -45,5 +45,8 @@
   },
   "[github-actions-workflow]": {
     "editor.defaultFormatter": "redhat.vscode-yaml"
-  }
+  },
+  "claudeCode.useTerminal": true,
+  "claudeCode.environmentVariables": [],
+  "workbench.editor.closeEmptyGroups": false
 }


### PR DESCRIPTION
## Summary
- Lazy-load nvm: shell startup ~8.6s → ~1.7s (zsh), ~2.4s → ~1.5s (bash). PATH preset keeps node/npm/npx callable so vim/nvim/coc still find node.
- Fix `VSCode` → `vscode` case in makefile link target.
- Add caveman plugin marketplace and show effort level in claude statusline.
- Set `dwmkerr` identity in iTerm profile init + minor vscode tweaks.

Will soak-test on this branch a few days before merging.