### PR TITLE
chore: add claude plugin marketplaces and terraform zsh completion

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -57,7 +57,6 @@
       "~/repos"
     ]
   },
-  "model": "sonnet",
   "hooks": {
     "Notification": [
       {

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -57,6 +57,7 @@
       "~/repos"
     ]
   },
+  "model": "sonnet",
   "hooks": {
     "Notification": [
       {
@@ -94,11 +95,10 @@
     "superpowers@claude-plugins-official": true,
     "cx@ccp": true,
     "ps@pspipe": true,
-    "protocols@dwmkerr-claude-toolkit": true,
-    "dwmkerr-toolkit@dwmkerr-claude-toolkit": true,
     "protocols@claude-toolkit": true,
     "gopls-lsp@claude-plugins-official": true,
-    "git-workforest@git-workforest": true
+    "git-workforest@git-workforest": true,
+    "dwmkerr-toolkit@dwmkerr-claude-toolkit": true
   },
   "extraKnownMarketplaces": {
     "git-workforest": {
@@ -106,9 +106,51 @@
         "source": "github",
         "repo": "dwmkerr/git-workforest"
       }
+    },
+    "claude-toolkit": {
+      "source": {
+        "source": "github",
+        "repo": "dwmkerr/claude-toolkit"
+      }
+    },
+    "context-engineering-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "NeoLabHQ/context-engineering-kit"
+      }
+    },
+    "agents-at-scale-ark": {
+      "source": {
+        "source": "github",
+        "repo": "mckinsey/agents-at-scale-ark"
+      }
+    },
+    "anthropic-agent-skills": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/skills"
+      }
+    },
+    "ccp": {
+      "source": {
+        "source": "github",
+        "repo": "syzygyhack/ccp"
+      }
+    },
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
+    },
+    "dwmkerr-claude-toolkit": {
+      "source": {
+        "source": "github",
+        "repo": "dwmkerr/dwmkerr-claude-toolkit"
+      }
     }
   },
   "alwaysThinkingEnabled": true,
-  "skipDangerousModePermissionPrompt": true,
-  "effortLevel": "high"
+  "effortLevel": "high",
+  "skipDangerousModePermissionPrompt": true
 }

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -14,3 +14,6 @@
 [ -r ~/.shell.sh ] && source ~/.shell.sh
 
 [[ "$TERM_PROGRAM" == "kiro" ]] && . "$(kiro --locate-shell-integration-path zsh)"
+
+autoload -U +X bashcompinit && bashcompinit
+complete -o nospace -C /opt/homebrew/bin/terraform terraform


### PR DESCRIPTION
## Summary
- Register all `extraKnownMarketplaces` in `claude/settings.json` so Claude Code can resolve and clone every enabled plugin. Previously only `git-workforest` was declared, causing 18 marketplace load errors.
- Add terraform shell completion to `zsh/zshrc` (generated by `terraform -install-autocomplete`).