### PR TITLE
feat: add opencode config with tmux notifications, skills, and MCP

### DIFF
--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -90,5 +90,7 @@ if [ -n "$DOTFILES_IDENTITY" ]; then
     identity_display="${bold}${fg_id_color}${DOTFILES_IDENTITY}${reset} "
 fi
 
-# Output the status line
-echo "${identity_display}${bold}${fg_blue}${pwd_display}${reset}${git_info} ${fg_grey}? for help${reset}${context_display}${model_display}"
+# Output the status line.
+# Claude Code has no single-key model switch; slash command `/model` is the
+# fastest path, shown in faint grey brackets after the effort level.
+echo "${identity_display}${bold}${fg_blue}${pwd_display}${reset}${git_info}${context_display}${model_display} ${fg_grey}(/model)${reset} ${fg_grey}? for help${reset}"

--- a/makefile
+++ b/makefile
@@ -27,6 +27,8 @@ link: # Creates symbolic links.
 	ln -sfn ${PWD}/claude/statusline.sh ~/.claude/statusline.sh || echo "error: can't link claude statusline.sh"
 	mkdir -p ~/.claude/hooks
 	ln -sfn ${PWD}/claude/hooks/tmux-notify.sh ~/.claude/hooks/tmux-notify.sh || echo "error: can't link tmux-notify.sh"
+	mkdir -p ~/.config/opencode/plugin
+	ln -sfn ${PWD}/opencode/plugin/tmux-notify.js ~/.config/opencode/plugin/tmux-notify.js || echo "error: can't link opencode tmux-notify.js"
 
 .PHONY: iterm-profiles
 iterm-profiles: # Install iTerm2 dynamic profiles.

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,0 +1,25 @@
+# opencode
+
+Config for the [opencode](https://opencode.ai) CLI. `make link` symlinks `plugin/tmux-notify.js` so opencode shares the Claude tmux notifications.
+
+## Notifications
+
+`plugin/tmux-notify.js` fires on `session.idle` and calls `~/.claude/hooks/tmux-notify.sh`, so opencode highlights the tmux window/pane/session like Claude does.
+
+## Skills
+
+Install into both agents with the [`skills`](https://github.com/vercel-labs/skills) CLI (symlinks, so repo edits are live):
+
+```bash
+npx skills add ~/repos/github/dwmkerr/claude-toolkit         --global --agent opencode --skill '*' -y
+npx skills add ~/repos/github/dwmkerr/dwmkerr-claude-toolkit --global --agent opencode --skill '*' -y
+```
+
+## MCP
+
+```bash
+opencode mcp add context7 --url https://mcp.context7.com/mcp
+opencode mcp add notion   --url https://mcp.notion.com/mcp     # then: opencode mcp auth notion
+opencode mcp add playwright -- npx -y @playwright/mcp@latest
+opencode mcp add spotify  -- node ~/repos/spotify-mcp-server/build/index.js
+```

--- a/opencode/plugin/tmux-notify.js
+++ b/opencode/plugin/tmux-notify.js
@@ -1,0 +1,25 @@
+// Reuse the Claude Code tmux notifier so opencode and Claude share one
+// notification mechanism (window/pane/session highlight + bell).
+const NOTIFY = `${process.env.HOME}/.claude/hooks/tmux-notify.sh`
+
+export const server = async ({ $ }) => {
+  // .nothrow() so a tmux/script failure never bubbles into the opencode session.
+  const run = (action) => $`${NOTIFY} ${action}`.nothrow()
+
+  return {
+    event: async ({ event }) => {
+      // session.idle = agent finished a turn → raise the notification.
+      if (event.type === "session.idle") {
+        await run("set")
+        return
+      }
+
+      // Agent started working again (user submitted) → clear, mirroring the
+      // Claude UserPromptSubmit clear. Property name is best-effort; tmux's own
+      // pane-focus-in hook clears on focus regardless, so a miss is harmless.
+      if (event.type === "session.status" && event.properties?.status === "busy") {
+        await run("clear")
+      }
+    },
+  }
+}

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -399,6 +399,60 @@ endif
 " Resize splits when terminal size changes (e.g., tmux zoom)
 autocmd VimResized * wincmd =
 
+" Auto-reload buffer when file changes on disk.
+" `autoread` is passive — it only acts when something prompts a check. The
+" focus/buffer/cursor autocmds cover the common case (vim regains focus and
+" you see fresh content). On neovim we additionally register a libuv fs_event
+" watcher per buffer so external changes reload even while nvim is in the
+" background.
+set autoread
+augroup auto_reload_on_change
+    autocmd!
+    autocmd FocusGained,BufEnter,CursorHold,CursorHoldI * silent! checktime
+    " Use <bar> not |; bare | ends the autocmd command and the rest runs at sourcetime.
+    autocmd FileChangedShellPost * echohl WarningMsg <bar> echo "File changed on disk. Buffer reloaded." <bar> echohl None
+augroup end
+
+if has('nvim')
+lua << EOF
+local watchers = {}
+local function watch(bufnr)
+    local path = vim.api.nvim_buf_get_name(bufnr)
+    if path == "" or watchers[bufnr] then return end
+    if vim.fn.filereadable(path) ~= 1 then return end
+    local handle = vim.uv.new_fs_event()
+    if not handle then return end
+    watchers[bufnr] = handle
+    -- fs_event fires off main loop; schedule_wrap hops back so vim API is safe.
+    -- Some editors rename-replace on save, which detaches kqueue. Re-arm watcher
+    -- after each event so subsequent changes still fire.
+    local function arm()
+        handle:start(path, {}, vim.schedule_wrap(function(err)
+            if err then return end
+            if not vim.api.nvim_buf_is_valid(bufnr) then return end
+            vim.api.nvim_buf_call(bufnr, function() vim.cmd("silent! checktime") end)
+            -- Terminal nvim needs an explicit redraw to repaint when reload
+            -- happens outside an input event (e.g. background fs_event).
+            vim.cmd("redraw")
+            handle:stop()
+            if vim.fn.filereadable(path) == 1 then arm() end
+        end))
+    end
+    arm()
+end
+local function unwatch(bufnr)
+    local h = watchers[bufnr]
+    if h then h:stop(); h:close(); watchers[bufnr] = nil end
+end
+vim.api.nvim_create_autocmd({"BufReadPost", "BufNewFile", "BufWritePost"}, {
+    callback = function(args) watch(args.buf) end,
+})
+vim.api.nvim_create_autocmd({"BufDelete", "BufWipeout"}, {
+    callback = function(args) unwatch(args.buf) end,
+})
+EOF
+endif
+
 " Splitjoin Plugin
 " Remember it like this: 's' for 'split', j splits down, k up.
 nmap sj :SplitjoinSplit<cr>


### PR DESCRIPTION
## Summary
- Add `opencode/` config managed by dotfiles, alongside Claude Code
- `plugin/tmux-notify.js`: opencode notification plugin reusing the Claude `tmux-notify.sh` — fires on `session.idle` for the same tmux window/pane/session highlight
- Wire the plugin symlink into `make link`
- `README.md`: install, notifications, skills (`npx skills` cross-agent install), and MCP (`opencode mcp add`) setup