### PR TITLE
feat: dispatch claude hooks via signalbox with tmux-notify fallback

### DIFF
--- a/claude/hooks/agent-notify.sh
+++ b/claude/hooks/agent-notify.sh
@@ -6,7 +6,7 @@
 # exec (stdin passes straight through): one less shell in the process tree,
 # so signalbox can identify the agent process for its liveness tracking.
 if command -v signalbox >/dev/null 2>&1; then
-  exec signalbox claude-hook 2>/dev/null
+  exec signalbox hook claude 2>/dev/null
 fi
 
 payload="$(cat)"

--- a/claude/hooks/agent-notify.sh
+++ b/claude/hooks/agent-notify.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Claude Code hook dispatcher. Prefers signalbox (which fires the session
+# event AND applies the tmux signals itself); falls back to the plain tmux
+# notify behaviour when signalbox is not installed. Always exits 0 — a
+# notifier must never break the agent that calls it.
+payload="$(cat)"
+
+if command -v signalbox >/dev/null 2>&1; then
+  printf '%s' "$payload" | signalbox claude-hook 2>/dev/null
+  exit 0
+fi
+
+# No signalbox on this machine: keep the original in-terminal signals.
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+case "$payload" in
+  *'"hook_event_name":"Notification"'*) "$dir/tmux-notify.sh" 2>/dev/null ;;
+  *'"hook_event_name":"UserPromptSubmit"'*) "$dir/tmux-notify.sh" clear 2>/dev/null ;;
+esac
+exit 0

--- a/claude/hooks/agent-notify.sh
+++ b/claude/hooks/agent-notify.sh
@@ -3,12 +3,13 @@
 # event AND applies the tmux signals itself); falls back to the plain tmux
 # notify behaviour when signalbox is not installed. Always exits 0 — a
 # notifier must never break the agent that calls it.
-payload="$(cat)"
-
+# exec (stdin passes straight through): one less shell in the process tree,
+# so signalbox can identify the agent process for its liveness tracking.
 if command -v signalbox >/dev/null 2>&1; then
-  printf '%s' "$payload" | signalbox claude-hook 2>/dev/null
-  exit 0
+  exec signalbox claude-hook 2>/dev/null
 fi
+
+payload="$(cat)"
 
 # No signalbox on this machine: keep the original in-terminal signals.
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -63,7 +63,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/tmux-notify.sh"
+            "command": "~/.claude/hooks/agent-notify.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/agent-notify.sh"
           }
         ]
       }
@@ -73,7 +83,27 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/tmux-notify.sh clear"
+            "command": "~/.claude/hooks/agent-notify.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/agent-notify.sh"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/agent-notify.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- All five Claude Code hook events route through a single dispatcher, claude/hooks/agent-notify.sh
- With signalbox installed it runs `signalbox claude-hook` (which also applies the tmux bell/background signals itself)
- Without signalbox it falls back to the original tmux-notify.sh behaviour
- Always exits 0 — a notifier must never break the agent