### PR TITLE
fix: follow symlinked ~/.shell.private.d when sourcing private files

### DIFF
--- a/shell.sh
+++ b/shell.sh
@@ -103,7 +103,7 @@ done
 if [ -d "$HOME/.shell.private.d" ]; then
     while IFS= read -r file; do
         [ -f "$file" ] && source "$file"
-    done < <(find "$HOME/.shell.private.d" -maxdepth 1 -type f ! -name '.*' 2>/dev/null)
+    done < <(find -L "$HOME/.shell.private.d" -maxdepth 1 -type f ! -name '.*' 2>/dev/null)
 fi
 
 # If we have a .private folder, source everything in it. This is useful for


### PR DESCRIPTION
## Summary
- `find` without `-L` does not descend a symlinked start directory on macOS (BSD find), so when `~/.shell.private.d` is a symlink (e.g. to this repo's `shell.private.d/`) the private files were silently never sourced - private aliases, functions and credentials all failed to load.
- Add `-L` so `find` follows the symlink. One-line change; no behaviour change for a real (non-symlink) directory.